### PR TITLE
fix: correct odd/even round description in compendium

### DIFF
--- a/src/packs/using-fantasy-trip-for-foundry-vtt/Using_Fantasy_Trip_for_Foundry_VTT_KaQZyogQKvA3r2vi.yml
+++ b/src/packs/using-fantasy-trip-for-foundry-vtt/Using_Fantasy_Trip_for_Foundry_VTT_KaQZyogQKvA3r2vi.yml
@@ -749,8 +749,8 @@ pages:
         is rolled for movement initiative, then all movement takes place, then
         combat takes place in order of adjusted DX (using the rolled initiative
         as a tie breaker).</p><p>In Foundry, this is implemented within the
-        standard round/turn structure with even numbered rounds as movement
-        rounds with a rolled initiative and odd numbered rounds as combat
+        standard round/turn structure with odd numbered rounds as movement
+        rounds with a rolled initiative and even numbered rounds as combat
         rounds. For example:</p><img
         src="systems/fantasy-trip/assets/images/instructions/combat_encounter_1.webp"
         /><p>Uldor has unexpectedly run into a lone Goblin. The GM creates an


### PR DESCRIPTION
## What this fixes

Closes #5

The "Using Fantasy Trip for Foundry VTT" compendium guide described the round types backwards:

> even numbered rounds as movement rounds... and odd numbered rounds as combat rounds

But the actual code in `combat.mjs` does the opposite:

```js
// Odd numbered rounds are movement rounds
get isMovementRound() {
  return this.started && !!(this.round % 2);
}

// Even numbered rounds are combat rounds
get isCombatRound() {
  return this.started && !(this.round % 2);
}
```

`round % 2` is truthy for odd rounds, making those the movement rounds. Even rounds (where `% 2 === 0`) are combat rounds.

## Fix

Swapped "odd" and "even" in the compendium text to match the implementation:

- Odd numbered rounds = movement (rolled initiative)
- Even numbered rounds = combat (DX-ordered)